### PR TITLE
fixed new cart

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -36,6 +36,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        depth = 1
 
 
 class Orders(ViewSet):
@@ -104,7 +105,8 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        payment = Payment.objects.get(pk=request.data["payment_type_id"])
+        order.payment_type = payment
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -234,7 +234,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- POST to profile/cart was not checking whether the order had been payed for
- Added " payment_type=None " to views/profile.py, line 237.

## Requests / Responses

**Request**

POST `/profile/cart` 

```json
{
    "product_id": 78
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 39,
    "product": {
        "id": 78,
        "name": "Cooper",
        "price": 625.27,
        "number_sold": 0,
        "description": "2004 MINI",
        "quantity": 1,
        "created_date": "2018-10-27",
        "location": "Cilaja",
        "image_path": null,
        "average_rating": "Product has no ratings"
    }
}
```

## Testing

Description of how to test code...

- [ ] After running the steps to reproduce the error, do a POST to http://localhost:8000/profile/cart
- [ ] Ensure that the product you just added is not in the order you previously added payment to with a GET to http://localhost:8000/orders/{ id of paid for order }
- [ ] Do a GET to http://localhost:8000/profile/cart to ensure the item is instead in the current, unpaid for cart


## Related Issues

- Fixes #23 
