### PR TITLE
removed line_items

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,7 +184,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- removed " cart["order"]["line_items"] = line_items.data " from line 187

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET http://localhost:8000/profile/cart

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 11,
    "url": "http://localhost:8000/orders/11",
    "created_date": "2021-08-31",
    "payment_type": null,
    "customer": {
        "url": "http://localhost:8000/customers/7",
        "phone_number": "212-555-1212",
        "address": "707 Park Place",
        "user": "http://localhost:8000/users/8"
    },
    "lineitems": [
        {
            "id": 38,
            "product": {
                "id": 84,
                "name": "3500",
                "price": 782.94,
                "number_sold": 0,
                "description": "1994 Chevrolet",
                "quantity": 2,
                "created_date": "2019-05-16",
                "location": "Iaçu",
                "image_path": null,
                "average_rating": "Product has no ratings"
            }
        },
        {
            "id": 39,
            "product": {
                "id": 78,
                "name": "Cooper",
                "price": 625.27,
                "number_sold": 0,
                "description": "2004 MINI",
                "quantity": 1,
                "created_date": "2018-10-27",
                "location": "Cilaja",
                "image_path": null,
                "average_rating": "Product has no ratings"
            }
        }
    ],
    "size": 2
}
```

## Testing

Description of how to test code...

- [ ] Run a GET request to http://localhost:8000/profile/cart
- [ ] Ensure that the line_items property is gone, but the cart "size" property is still returned

## Related Issues

- Fixes #24
