### PR TITLE
added new check

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -52,6 +52,7 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["id"], 1)
         self.assertEqual(json_response["size"], 1)
         self.assertEqual(len(json_response["lineitems"]), 1)
+        self.assertEqual(json_response['payment_type'], None)
 
 
     def test_remove_product_from_order(self):


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Added " self.assertEqual(json_response['payment_type'], None) " on line 55
- This will check that the cart has no pay type and therefore is an open order

## Testing

Description of how to test code...

- [ ] Run command in terminal:
```
python3 manage.py test tests -v 1
```
- [ ] Ensure all tests pass

## Related Issues

- Fixes #10 
